### PR TITLE
Detect and install gemstash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Google::Cloud::Gemserver
 
-[![Build Status](https://travis-ci.org/GoogleCloudPlatform/google-cloud-gemserver.svg?branch=master)](https://travis-ci.org/GoogleCloudPlatform/google-cloud-ruby)
+[![Build Status](https://travis-ci.org/GoogleCloudPlatform/google-cloud-gemserver.svg?branch=master)](https://travis-ci.org/GoogleCloudPlatform/google-cloud-gemserver)
 
 This gem is a tool that lets you manage, interact with, and deploy a [private gem
 server](https://github.com/bundler/gemstash) to a Google Cloud Platform project.

--- a/bin/google-cloud-gemserver
+++ b/bin/google-cloud-gemserver
@@ -1,5 +1,9 @@
 #!/usr/bin/env ruby
 require "bundler/setup"
+require "google/cloud/gemserver/gemstash_installer"
+
+Google::Cloud::Gemserver::GemstashInstaller.check_and_install_gemstash
+
 require "google/cloud/gemserver/cli"
 
 Google::Cloud::Gemserver::CLI.start ARGV

--- a/lib/google/cloud/gemserver.rb
+++ b/lib/google/cloud/gemserver.rb
@@ -22,13 +22,14 @@ module Google
     # a gemserver to a Google Cloud Platform project.
     #
     module Gemserver
-      autoload :CLI,           "google/cloud/gemserver/cli"
-      autoload :VERSION,       "google/cloud/gemserver/version"
-      autoload :Configuration, "google/cloud/gemserver/configuration"
-      autoload :StorageSync,   "google/cloud/gemserver/storage_sync"
-      autoload :GCS,           "google/cloud/gemserver/gcs"
-      autoload :Authentication,"google/cloud/gemserver/authentication"
-      autoload :Backend,       "google/cloud/gemserver/backend"
+      autoload :CLI,               "google/cloud/gemserver/cli"
+      autoload :VERSION,           "google/cloud/gemserver/version"
+      autoload :Configuration,     "google/cloud/gemserver/configuration"
+      autoload :StorageSync,       "google/cloud/gemserver/storage_sync"
+      autoload :GCS,               "google/cloud/gemserver/gcs"
+      autoload :Authentication,    "google/cloud/gemserver/authentication"
+      autoload :Backend,           "google/cloud/gemserver/backend"
+      autoload :GemstashInstaller, "google/cloud/gemserver/gemstash_installer"
     end
   end
 end

--- a/lib/google/cloud/gemserver/gemstash_installer.rb
+++ b/lib/google/cloud/gemserver/gemstash_installer.rb
@@ -1,0 +1,118 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "google/cloud/gemserver"
+require "rubygems/dependency_installer"
+
+module Google
+  module Cloud
+    module Gemserver
+      ##
+      #
+      # # GemstashInstaller
+      #
+      # Responsible for checking a valid version of gemstash is installed and
+      # upgrades its version if invalid. The gemstash installation is deemed
+      # valid if it supports protected (authorized) gem fetches.
+      module GemstashInstaller
+
+        ##
+        # The official name of the gemstash gem
+        GEM_NAME = "gemstash".freeze
+
+        ##
+        # The URL to the official gemstash repository.
+        GEM_URL = "https://github.com/bundler/gemstash.git".freeze
+
+        ##
+        # The name of the special permission in gemstash enabling
+        # protected fetches.
+        PERMISSION = "fetch".freeze
+
+        ##
+        # Checks the installed version of gemstash and upgrades it if necessary
+        # . If it does not exist, the most recent version of gemstash is
+        # installed.
+        def self.check_and_install_gemstash
+          if gemstash_detected
+            upgrade_gemstash unless valid_gemstash
+          else
+            install_gemstash
+          end
+        end
+
+        ##
+        # @private Detects if gemstash is installed on the user's machine.
+        #
+        # @return [Boolean]
+        def self.gemstash_detected
+          dep = Gem::Dependency.new GEM_NAME
+          !dep.matching_specs.max_by(&:version).nil?
+        end
+
+        ##
+        # @private Determines if the gemstash version is valid by the presence
+        # of the "fetch" permission which enables protected fetching.
+        #
+        # @return [Boolean]
+        def self.valid_gemstash
+          require "gemstash"
+          Gemstash::Authorization::VALID_PERMISSIONS.include? PERMISSION
+        end
+
+        ##
+        # @private Installs the newest version of gemstash by cloning the
+        # public repository's master branch.
+        def self.install_gemstash
+          puts "Installing core missing dependency (gemstash)..."
+          clone_repo
+          Dir.chdir GEM_NAME do
+            spec = Gem::Specification.load "#{GEM_NAME}.gemspec"
+            gem = Gem::Package.build spec
+            Gem::DependencyInstaller.new.install gem
+          end
+          cleanup
+        end
+
+        ##
+        # @private Uninstalls the current version of gemstash.
+        def self.uninstall_gemstash
+          puts "Uninstalling gemstash..."
+          system "gem uninstall -x gemstash"
+        end
+
+        ##
+        # @private Upgrades the current installed gemstash version to the
+        # latest version on the public repository.
+        def self.upgrade_gemstash
+          puts "Upgrading gemstash by reinstalling it..."
+          uninstall_gemstash
+          install_gemstash
+        end
+
+        ##
+        # @private Clones the public gemstash repository.
+        def self.clone_repo
+          system "git clone #{GEM_URL}"
+        end
+
+        ##
+        # @private Deletes the temporarily cloned gemstash repository.
+        def self.cleanup
+          system "rm -rf #{GEM_NAME}"
+        end
+      end
+    end
+  end
+end

--- a/lib/google/cloud/gemserver/gemstash_installer.rb
+++ b/lib/google/cloud/gemserver/gemstash_installer.rb
@@ -74,11 +74,11 @@ module Google
         ##
         # @private Installs the newest version of gemstash by cloning the
         # public repository's master branch.
-        def self.install_gemstash
+        def self.install_gemstash should_upgrade = false
           puts "Installing core missing dependency (gemstash)..."
           begin
             clone_repo
-            build_and_install_gem
+            build_and_install_gem should_upgrade
           ensure
             cleanup
           end
@@ -87,9 +87,10 @@ module Google
         ##
         # @private Builds gemstash from the latest revision on the master
         # branch of its public repository then installs from the gemspec.
-        def self.build_and_install_gem
+        def self.build_and_install_gem should_upgrade = false
           Dir.chdir GEM_NAME do
             spec = Gem::Specification.load "#{GEM_NAME}.gemspec"
+            uninstall_gemstash(spec.version.version) if should_upgrade
             gem = Gem::Package.build spec
             Gem::DependencyInstaller.new.install gem
           end
@@ -97,9 +98,9 @@ module Google
 
         ##
         # @private Uninstalls the current version of gemstash.
-        def self.uninstall_gemstash
-          puts "Uninstalling gemstash..."
-          system "gem uninstall -x gemstash"
+        def self.uninstall_gemstash version
+          puts "Uninstalling gemstash v#{version}..."
+          system "gem uninstall -x gemstash -v #{version}"
         end
 
         ##
@@ -107,8 +108,7 @@ module Google
         # latest version on the public repository.
         def self.upgrade_gemstash
           puts "Upgrading gemstash by reinstalling it..."
-          uninstall_gemstash
-          install_gemstash
+          install_gemstash should_upgrade: true
         end
 
         ##

--- a/lib/google/cloud/gemserver/gemstash_installer.rb
+++ b/lib/google/cloud/gemserver/gemstash_installer.rb
@@ -76,13 +76,23 @@ module Google
         # public repository's master branch.
         def self.install_gemstash
           puts "Installing core missing dependency (gemstash)..."
-          clone_repo
+          begin
+            clone_repo
+            build_and_install_gem
+          ensure
+            cleanup
+          end
+        end
+
+        ##
+        # @private Builds gemstash from the latest revision on the master
+        # branch of its public repository then installs from the gemspec.
+        def self.build_and_install_gem
           Dir.chdir GEM_NAME do
             spec = Gem::Specification.load "#{GEM_NAME}.gemspec"
             gem = Gem::Package.build spec
             Gem::DependencyInstaller.new.install gem
           end
-          cleanup
         end
 
         ##
@@ -104,7 +114,7 @@ module Google
         ##
         # @private Clones the public gemstash repository.
         def self.clone_repo
-          system "git clone #{GEM_URL}"
+          system "git clone #{GEM_URL} > /dev/null 2>&1"
         end
 
         ##

--- a/test/google/cloud/gemserver/gemstash_installer_test.rb
+++ b/test/google/cloud/gemserver/gemstash_installer_test.rb
@@ -17,49 +17,156 @@ require "helper"
 describe Google::Cloud::Gemserver::GemstashInstaller do
   describe ".check_and_install_gemstash" do
     it "calls gemstash_detected" do
-      #TODO
+      mock = Minitest::Mock.new
+      mock.expect :call, true
+      GCG::GemstashInstaller.stub :gemstash_detected, mock do
+        GCG::GemstashInstaller.stub :valid_gemstash, true do
+          GCG::GemstashInstaller.check_and_install_gemstash
+          mock.verify
+        end
+      end
     end
 
     it "calls upgrade_gemstash or install_gemstash" do
-      #TODO
+      mock = Minitest::Mock.new
+      mock.expect :call, nil
+      GCG::GemstashInstaller.stub :gemstash_detected, true do
+        GCG::GemstashInstaller.stub :valid_gemstash, false do
+          GCG::GemstashInstaller.stub :upgrade_gemstash, mock do
+            GCG::GemstashInstaller.stub :uninstall_gemstash, nil do
+              GCG::GemstashInstaller.stub :install_gemstash, nil do
+                GCG::GemstashInstaller.check_and_install_gemstash
+                mock.verify
+              end
+            end
+          end
+        end
+      end
+      mock.expect :call, nil
+      GCG::GemstashInstaller.stub :gemstash_detected, false do
+        GCG::GemstashInstaller.stub :install_gemstash, mock do
+          GCG::GemstashInstaller.check_and_install_gemstash
+          mock.verify
+        end
+      end
     end
 
     it "calls valid_gemstash if gemstash is installed" do
-      #TODO
+      mock = Minitest::Mock.new
+      mock.expect :call, nil
+      GCG::GemstashInstaller.stub :gemstash_detected, true do
+        GCG::GemstashInstaller.stub :upgrade_gemstash, nil do
+          GCG::GemstashInstaller.stub :valid_gemstash, mock do
+            GCG::GemstashInstaller.check_and_install_gemstash
+            mock.verify
+          end
+        end
+      end
     end
   end
 
   describe ".gemstash_detected" do
     it "correctly checks if gemstash is installed" do
-      #TODO
+      out = `gem which gemstash`
+      assert_equal !out.empty?, GCG::GemstashInstaller.gemstash_detected
     end
   end
 
   describe ".install_gemstash" do
     it "calls clone_repo" do
-      #TODO
+      mock = Minitest::Mock.new
+      mock.expect :call, nil
+      GCG::GemstashInstaller.stub :build_and_install_gem, nil do
+        GCG::GemstashInstaller.stub :clone_repo, mock do
+          GCG::GemstashInstaller.stub :cleanup, nil do
+            GCG::GemstashInstaller.install_gemstash
+            mock.verify
+          end
+        end
+      end
     end
 
-    it "calls Gem::Package.build" do
-      #TODO
-    end
-
-    it "calls Gem::DependencyInstaller" do
-      #TODO
+    it "calls build_and_install_gem" do
+      mock = Minitest::Mock.new
+      mock.expect :call, nil
+      GCG::GemstashInstaller.stub :build_and_install_gem, mock do
+        GCG::GemstashInstaller.stub :clone_repo, nil do
+          GCG::GemstashInstaller.stub :cleanup, nil do
+            GCG::GemstashInstaller.install_gemstash
+            mock.verify
+          end
+        end
+      end
     end
 
     it "calls cleanup" do
-      #TODO
+      mock = Minitest::Mock.new
+      mock.expect :call, nil
+      GCG::GemstashInstaller.stub :build_and_install_gem, nil do
+        GCG::GemstashInstaller.stub :clone_repo, nil do
+          GCG::GemstashInstaller.stub :cleanup, mock do
+            GCG::GemstashInstaller.install_gemstash
+            mock.verify
+          end
+        end
+      end
     end
   end
 
   describe ".upgrade_gemstash" do
     it "calls uninstall_gemstash" do
-      #TODO
+      mock = Minitest::Mock.new
+      mock.expect :call, nil
+      GCG::GemstashInstaller.stub :uninstall_gemstash, mock do
+        GCG::GemstashInstaller.stub :install_gemstash, nil do
+          GCG::GemstashInstaller.upgrade_gemstash
+          mock.verify
+        end
+      end
     end
 
     it "calls install_gemstash" do
-      #TODO
+      mock = Minitest::Mock.new
+      mock.expect :call, nil
+      GCG::GemstashInstaller.stub :install_gemstash, mock do
+        GCG::GemstashInstaller.stub :uninstall_gemstash, nil do
+          GCG::GemstashInstaller.upgrade_gemstash
+          mock.verify
+        end
+      end
+    end
+  end
+
+  describe ".uninstall_gemstash" do
+    it "calls gem uninstall -x gemstash" do
+      mock = Minitest::Mock.new
+      mock.expect :call, false, ["gem uninstall -x gemstash"]
+      GCG::GemstashInstaller.stub :system, mock do
+        GCG::GemstashInstaller.uninstall_gemstash
+        mock.verify
+      end
+    end
+  end
+
+  describe ".clone_repo" do
+    it "calls git clone" do
+      mock = Minitest::Mock.new
+      mock.expect :call, false, ["git clone #{GCG::GemstashInstaller::GEM_URL}"]
+      GCG::GemstashInstaller.stub :system, mock do
+        GCG::GemstashInstaller.clone_repo
+        mock.verify
+      end
+    end
+  end
+
+  describe "cleanup" do
+    it "calls rm -rf gemstash" do
+      mock = Minitest::Mock.new
+      mock.expect :call, false, ["rm -rf gemstash"]
+      GCG::GemstashInstaller.stub :system, mock do
+        GCG::GemstashInstaller.cleanup
+        mock.verify
+      end
     end
   end
 end

--- a/test/google/cloud/gemserver/gemstash_installer_test.rb
+++ b/test/google/cloud/gemserver/gemstash_installer_test.rb
@@ -1,0 +1,65 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Gemserver::GemstashInstaller do
+  describe ".check_and_install_gemstash" do
+    it "calls gemstash_detected" do
+      #TODO
+    end
+
+    it "calls upgrade_gemstash or install_gemstash" do
+      #TODO
+    end
+
+    it "calls valid_gemstash if gemstash is installed" do
+      #TODO
+    end
+  end
+
+  describe ".gemstash_detected" do
+    it "correctly checks if gemstash is installed" do
+      #TODO
+    end
+  end
+
+  describe ".install_gemstash" do
+    it "calls clone_repo" do
+      #TODO
+    end
+
+    it "calls Gem::Package.build" do
+      #TODO
+    end
+
+    it "calls Gem::DependencyInstaller" do
+      #TODO
+    end
+
+    it "calls cleanup" do
+      #TODO
+    end
+  end
+
+  describe ".upgrade_gemstash" do
+    it "calls uninstall_gemstash" do
+      #TODO
+    end
+
+    it "calls install_gemstash" do
+      #TODO
+    end
+  end
+end


### PR DESCRIPTION
Before running any `google-cloud-gemserver` command the current version of gemstash is checked to ensure it supports protected gem fetches. If not, gemstash is installed from the [bundler repository](https://github.com/bundler/gemstash). Once a new version of gemstash is [released](https://github.com/bundler/gemstash/issues/151) with that feature this component can be removed.