### PR TITLE
Run acceptance and integration tests only for project members on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,13 +40,12 @@ script:
       sudo chmod 777 /cloudsql;
 
       echo "Start cloud_sql_proxy";
-      ./cloud_sql_proxy -instances=$CLOUD_SQL_ICN -dir=/cloudsql &;
+      ./cloud_sql_proxy -instances=$CLOUD_SQL_ICN -dir=/cloudsql &
 
       echo "Setup gemserver keys";
       touch ~/.gem/credentials;
       chmod 0600 ~/.gem/credentials;
-      # Write :GEMSERVER_KEY_NAME: $GEMSERVER_KEY to ~/.gem/credentials in a
-      # convoluted way because Travis parses strings with : as mappings
+      echo "Writing [colon]GEMSERVER_KEY_NAME[colon] $GEMSERVER_KEY to ~/.gem/credentials in a convoluted way because Travis parses strings with [colon] as mappings"
       echo :$GEMSERVER_KEY_NAME >> ~/.gem/credentials;
       sed -i '$s/$/:/' ~/.gem/credentials;
       sed -i '$s/$/ '"$GEMSERVER_KEY"'/' ~/.gem/credentials;

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,32 +2,7 @@ language: ruby
 rvm:
   - 2.3.1
 
-install:
-  - echo "Decrypt service account key file"
-  - openssl aes-256-cbc -K $encrypted_40f8911e359f_key -iv $encrypted_40f8911e359f_iv -in secrets/service-account-key.json.enc -out secrets/service-account-key.json -d
-
-  - echo "Install gcloud SDK"
-  - export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
-  - echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-  - curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-  - sudo apt-get update && sudo apt-get install google-cloud-sdk
-
-  - echo "Install and setup Cloud SQL proxy"
-  - wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64
-  - mv cloud_sql_proxy.linux.amd64 cloud_sql_proxy
-  - chmod +x cloud_sql_proxy
-  - sudo mkdir /cloudsql
-  - sudo chmod 777 /cloudsql
-
 script:
-
-  - echo "Authenticate with gcloud"
-  - gcloud auth activate-service-account --key-file secrets/service-account-key.json
-
-  - gcloud config set project $PROJECT_NAME
-
-  - echo "Start cloud_sql_proxy"
-  - ./cloud_sql_proxy -instances=$CLOUD_SQL_ICN -dir=/cloudsql &
 
   - echo "Install gem dependencies"
   - bundle install
@@ -35,26 +10,53 @@ script:
   - echo "Install and setup google-cloud-gemserver"
   - rake install
   - google-cloud-gemserver gen_config
-  - openssl aes-256-cbc -K $encrypted_40f8911e359f_key -iv $encrypted_40f8911e359f_iv -in secrets/app.yaml.enc -out secrets/app.yaml -d
-  - cp secrets/app.yaml ~/.google_cloud_gemserver/app.yaml
-
-  - echo "Setup gemserver keys"
-  - touch ~/.gem/credentials
-  - chmod 0600 ~/.gem/credentials
-  # Write :GEMSERVER_KEY_NAME: $GEMSERVER_KEY to ~/.gem/credentials in a
-  # convoluted way because Travis parses strings with : as mappings
-  - echo :$GEMSERVER_KEY_NAME >> ~/.gem/credentials
-  - sed -i '$s/$/:/' ~/.gem/credentials
-  - sed -i '$s/$/ '"$GEMSERVER_KEY"'/' ~/.gem/credentials
-  - bundle config $GEMSERVER_PRIVATE_URL $GEMSERVER_KEY
 
   - echo "Run unit tests"
   - bundle exec rake test
 
-  - echo "Run acceptance tests"
-  - gcloud config set project $PROJECT_NAME
-  - host=$GEMSERVER_PRIVATE_URL key=$GEMSERVER_KEY_NAME bundle exec rake acceptance
+  # You need to be a project member to run acceptance and integration tests
+  - if [ -z ${PROJECT_MEMBER+x} ]; then
+      echo "User is not a project member. Skipping acceptance and integration tests.";
+    else
+      echo "Decrypt secrets";
+      openssl aes-256-cbc -K $encrypted_40f8911e359f_key -iv $encrypted_40f8911e359f_iv -in secrets/service-account-key.json.enc -out secrets/service-account-key.json -d;
+      openssl aes-256-cbc -K $encrypted_40f8911e359f_key -iv $encrypted_40f8911e359f_iv -in secrets/app.yaml.enc -out secrets/app.yaml -d;
+      cp secrets/app.yaml ~/.google_cloud_gemserver/app.yaml;
 
-  - echo "Run integration tests"
-  - gcloud config set project $PROJECT_NAME
-  - host=$GEMSERVER_PRIVATE_URL key=$GEMSERVER_KEY_NAME bundle exec rake integration
+      echo "Install gcloud SDK";
+      export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)";
+      echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list;
+      curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -;
+      sudo apt-get update && sudo apt-get install google-cloud-sdk;
+
+      echo "Authenticate with gcloud";
+      gcloud auth activate-service-account --key-file secrets/service-account-key.json;
+
+      echo "Install and setup Cloud SQL proxy";
+      wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64;
+      mv cloud_sql_proxy.linux.amd64 cloud_sql_proxy;
+      chmod +x cloud_sql_proxy;
+      sudo mkdir /cloudsql;
+      sudo chmod 777 /cloudsql;
+
+      echo "Start cloud_sql_proxy";
+      ./cloud_sql_proxy -instances=$CLOUD_SQL_ICN -dir=/cloudsql &;
+
+      echo "Setup gemserver keys";
+      touch ~/.gem/credentials;
+      chmod 0600 ~/.gem/credentials;
+      # Write :GEMSERVER_KEY_NAME: $GEMSERVER_KEY to ~/.gem/credentials in a
+      # convoluted way because Travis parses strings with : as mappings
+      echo :$GEMSERVER_KEY_NAME >> ~/.gem/credentials;
+      sed -i '$s/$/:/' ~/.gem/credentials;
+      sed -i '$s/$/ '"$GEMSERVER_KEY"'/' ~/.gem/credentials;
+      bundle config $GEMSERVER_PRIVATE_URL $GEMSERVER_KEY;
+
+      echo "Run acceptance tests";
+      gcloud config set project $PROJECT_NAME;
+      host=$GEMSERVER_PRIVATE_URL key=$GEMSERVER_KEY_NAME bundle exec rake acceptance;
+
+      echo "Run integration tests";
+      gcloud config set project $PROJECT_NAME;
+      host=$GEMSERVER_PRIVATE_URL key=$GEMSERVER_KEY_NAME bundle exec rake integration;
+    fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,3 +40,10 @@ tests.
     Ensure cloud_sql_proxy is running and connected to the CloudSQL instance of
     your testing gemserver (dev prefix) in app.yaml.
     `bundle exec rake integration host=test-gemserver-url.com key=my-test-key`
+
+### Travis PR Builds
+
+By default, unit tests will always run for every update to a PR. Acceptance and
+integration tests will run after a PR is merged. If tests break, please submit a
+separate PR to fix the issues.
+

--- a/google-cloud-gemserver.gemspec
+++ b/google-cloud-gemserver.gemspec
@@ -3,6 +3,13 @@
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+dirs = ["bin", "lib", "acceptance", "integration", "test", "secrets", "docs"]
+files = [
+  "google-cloud-gemserver.gemspec", "Gemfile", "Gemfile.lock", "Rakefile",
+  "CONTRIBUTING.md", "README.md", "LICENSE", ".travis.yml", ".yardopts",
+  ".rubocop.yml"
+]
+
 require "google/cloud/gemserver/version"
 
 Gem::Specification.new do |spec|

--- a/google-cloud-gemserver.gemspec
+++ b/google-cloud-gemserver.gemspec
@@ -3,13 +3,6 @@
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-dirs = ["bin", "lib", "acceptance", "integration", "test", "secrets", "docs"]
-files = [
-  "google-cloud-gemserver.gemspec", "Gemfile", "Gemfile.lock", "Rakefile",
-  "CONTRIBUTING.md", "README.md", "LICENSE", ".travis.yml", ".yardopts",
-  ".rubocop.yml"
-]
-
 require "google/cloud/gemserver/version"
 
 Gem::Specification.new do |spec|


### PR DESCRIPTION
(branched off this [PR](https://github.com/GoogleCloudPlatform/google-cloud-gemserver/pull/2))

By default, unit tests will always be run. To run acceptance and integration tests, a project member will need to create a PR from within GoogleCloudPlatform/google-cloud-gemserver repository (not a fork).