### PR TITLE
Run migrations with transactions disabled

### DIFF
--- a/lib/google/cloud/gemserver/cli/request.rb
+++ b/lib/google/cloud/gemserver/cli/request.rb
@@ -40,7 +40,7 @@ module Google
           # gemserver.
           def initialize url = nil
             gemserver_url = url.nil? == true ? remote : url
-            @http = Net::HTTP.new gemserver_url, 8080
+            @http = Net::HTTP.new gemserver_url
           end
 
           ##

--- a/lib/google/cloud/gemserver/cli/request.rb
+++ b/lib/google/cloud/gemserver/cli/request.rb
@@ -40,7 +40,7 @@ module Google
           # gemserver.
           def initialize url = nil
             gemserver_url = url.nil? == true ? remote : url
-            @http = Net::HTTP.new gemserver_url
+            @http = Net::HTTP.new gemserver_url, 8080
           end
 
           ##

--- a/lib/patched/env.rb
+++ b/lib/patched/env.rb
@@ -20,10 +20,25 @@ module PatchedEnv
   ##
   # Monkey patch to support Cloud SQL as an adapter
   def db
+    db = instance_variable_get :@db
+    return db if db
+
     if config[:db_adapter] == "cloud_sql"
       connection = Sequel.connect config.database_connection_config
-      Gemstash::Env.migrate connection
+      instance_variable_set :@db, connection
+      migrate_cloud_sql connection
       connection
+    else
+      super
+    end
+  end
+
+  def migrate_cloud_sql database
+    if config[:db_adapter] == "cloud_sql"
+      Sequel.extension :migration
+      lib_dir = Gem::Specification.find_by_name("gemstash").lib_dirs_glob
+      m_dir = "#{lib_dir}/gemstash/migrations"
+      Sequel::Migrator.run database, m_dir, use_transactions: false
     else
       super
     end

--- a/lib/patched/env.rb
+++ b/lib/patched/env.rb
@@ -20,28 +20,22 @@ module PatchedEnv
   ##
   # Monkey patch to support Cloud SQL as an adapter
   def db
-    db = instance_variable_get :@db
-    return db if db
+    return @db if @db
 
-    if config[:db_adapter] == "cloud_sql"
-      connection = Sequel.connect config.database_connection_config
-      instance_variable_set :@db, connection
-      migrate_cloud_sql connection
-      connection
-    else
-      super
-    end
+    @db = if config[:db_adapter] == "cloud_sql"
+        connection = Sequel.connect config.database_connection_config
+        migrate_cloud_sql connection
+        connection
+      else
+        super
+      end
   end
 
   def migrate_cloud_sql database
-    if config[:db_adapter] == "cloud_sql"
-      Sequel.extension :migration
-      lib_dir = Gem::Specification.find_by_name("gemstash").lib_dirs_glob
-      m_dir = "#{lib_dir}/gemstash/migrations"
-      Sequel::Migrator.run database, m_dir, use_transactions: false
-    else
-      super
-    end
+    Sequel.extension :migration
+    lib_dir = Gem::Specification.find_by_name("gemstash").lib_dirs_glob
+    m_dir = "#{lib_dir}/gemstash/migrations"
+    Sequel::Migrator.run database, m_dir, use_transactions: false
   end
 end
 


### PR DESCRIPTION
Should fix [this](https://github.com/GoogleCloudPlatform/google-cloud-gemserver/issues/6) bug where having `use_transactions: true` resulted in `Mysql2::Error: SAVEPOINT autopoint_1 does not exist` due to implicit commit when `Gemstash::Env.migrate` ran.

Database connections are now properly cached, as well. 