### PR TITLE
Use gemstash 1.1.0 instead of ref to commit on github

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
 gem "concurrent-ruby", require: "concurrent"
-gem "gemstash", git: "https://github.com/bundler/gemstash.git", ref: "a5a78e2"
+gem "gemstash", "~> 1.1.0"
 gemspec


### PR DESCRIPTION
Fixes #11 