### PR TITLE
Add confirmation after create

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ Or install it yourself as:
       google-cloud-gemserver delete_key
 
     Options:
-      -r, [--remote=REMOTE]            # The gemserver URL, i.e. gemserver.com
-      -k, [--key=KEY]                  # The key to delete
+    *  -r, [--remote=REMOTE]            # The gemserver URL, i.e. gemserver.com
+    *  -k, [--key=KEY]                  # The key to delete
 
       Deletes a given key
 

--- a/docs/usage_example.md
+++ b/docs/usage_example.md
@@ -9,7 +9,7 @@ In doing it, it creates a Cloud SQL instance. If you wish to use an existing
 Cloud SQL instance run `google-cloud-gemserver create --use-proj [PROJECT_ID]
 --use-inst [CLOUD_SQL INSTANCE NAME]`
 
-** If you do not want to deploy to GCP and instead want to use the Cloud SQL
+Note: If you do not want to deploy to GCP and instead want to use the Cloud SQL
 instance in dev_config.yml or sqlite3 database to run the gemserver completely
 locally then prepend "APP_ENV=dev" or "APP_ENV=test" to google-cloud-gemserver
 commands, accordingly. Read [running locally](running-locally.md) for more
@@ -24,9 +24,9 @@ To push a gem, simply run `gem push --key [key] [path-to-gem] --host
 
 Here is an example:
 
-** assume you have deployed a gemserver to a project called my-gemserver. This
+* assume you have deployed a gemserver to a project called my-gemserver. This
   project has the following url: http://my-gemserver.appspot.com
-** assume you created a key with read and write permissions called my-key (read
+* assume you created a key with read and write permissions called my-key (read
   more about key [here](key.md) for more information)
 
 1) Create a new gem with `bundle gem private-gem`
@@ -43,7 +43,7 @@ will fail.
 
 ## Installing Gems
 
-** same assumptions as above
+Note: same assumptions as above
 
 1) Add `source "http://my-gemserver.appspot.com" to the top of your Gemfile.
 This lets the gemserver fetch private gem dependencies from rubygems.org if they

--- a/lib/google/cloud/gemserver/authentication.rb
+++ b/lib/google/cloud/gemserver/authentication.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require "google/cloud/gemserver"
+require "json"
 
 module Google
   module Cloud
@@ -91,10 +92,11 @@ module Google
         #
         # @return [String]
         def curr_user
-          raw = run_cmd "gcloud auth list"
-          active_idx = raw.index("*")
-          abort "You are not authenticated with gcloud" unless active_idx
-          raw[active_idx + 1 .. raw.index("\n", active_idx)].strip
+          raw = run_cmd "gcloud auth list --format json"
+          JSON.load(raw).map do |i|
+            return i["account"] if i["status"] == "ACTIVE"
+          end
+          abort "You are not authenticated with gcloud"
         end
 
         ##

--- a/lib/google/cloud/gemserver/cli/server.rb
+++ b/lib/google/cloud/gemserver/cli/server.rb
@@ -70,9 +70,10 @@ module Google
               puts "Beginning gemserver deployment..."
               path = Configuration::SERVER_PATH
               status = system "gcloud app deploy #{path}/app.yaml -q"
+              fail "Gemserver deployment failed. " unless status
               @config.save_to_cloud
               setup_default_keys
-              display_next_steps if status
+              display_next_steps
             ensure
               cleanup
             end
@@ -82,10 +83,7 @@ module Google
           # Updates the gemserver on a Google Cloud Platform project by
           # redeploying it.
           def update
-            was_deployed = user_input "Has the gemserver been deployed" \
-              "before with the current settings (y or n)? If not, run " \
-              "`google-cloud-gemserver create` first."
-            return unless was_deployed.downcase == "y"
+            return unless Configuration.deployed?
             puts "Updating gemserver..."
             deploy
           end
@@ -97,6 +95,7 @@ module Google
           # was deployed to.
           def delete proj_id
             puts "Deleting gemserver with parent project"
+            Configuration.new.delete_from_cloud
             run_cmd "gcloud projects delete #{proj_id}"
           end
 

--- a/lib/google/cloud/gemserver/cli/server.rb
+++ b/lib/google/cloud/gemserver/cli/server.rb
@@ -68,9 +68,11 @@ module Google
               return start if ["test", "dev"].include? ENV["APP_ENV"]
               prepare_dir
               puts "Beginning gemserver deployment..."
-              run_cmd "gcloud app deploy #{Configuration::SERVER_PATH}/app.yaml -q"
+              path = Configuration::SERVER_PATH
+              status = system "gcloud app deploy #{path}/app.yaml -q"
               @config.save_to_cloud
               setup_default_keys
+              display_next_steps if status
             ensure
               cleanup
             end
@@ -80,6 +82,10 @@ module Google
           # Updates the gemserver on a Google Cloud Platform project by
           # redeploying it.
           def update
+            was_deployed = user_input "Has the gemserver been deployed" \
+              "before with the current settings (y or n)? If not, run " \
+              "`google-cloud-gemserver create` first."
+            return unless was_deployed.downcase == "n"
             puts "Updating gemserver..."
             deploy
           end
@@ -145,6 +151,18 @@ module Google
           def sanitize_name name
             name = name.chomp
             name.gsub(/[^0-9a-z ]/i, "")
+          end
+
+          ##
+          # @private Outputs helpful information to the console indicating the
+          # URL the gemserver is running at and how to use the gemserver.
+          def display_next_steps
+            puts "The gemserver has been deployed! It is running on #{remote}"
+            puts "To see how to use your gemserver to push and download gems" \
+              "read https://github.com/GoogleCloudPlatform/google-cloud-" \
+              "gemserver/blob/master/docs/usage_example.md for some examples."
+            puts "For general information, visit https://github.com/" \
+              "GoogleCloudPlatform/google-cloud-gemserver/blob/master/README.md"
           end
 
           ##

--- a/lib/google/cloud/gemserver/cli/server.rb
+++ b/lib/google/cloud/gemserver/cli/server.rb
@@ -96,7 +96,7 @@ module Google
           # was deployed to.
           def delete proj_id
             puts "Deleting gemserver with parent project"
-            Configuration.new.delete_from_cloud
+            @config.delete_from_cloud
             run_cmd "gcloud projects delete #{proj_id}"
           end
 

--- a/lib/google/cloud/gemserver/cli/server.rb
+++ b/lib/google/cloud/gemserver/cli/server.rb
@@ -85,7 +85,7 @@ module Google
             was_deployed = user_input "Has the gemserver been deployed" \
               "before with the current settings (y or n)? If not, run " \
               "`google-cloud-gemserver create` first."
-            return unless was_deployed.downcase == "n"
+            return unless was_deployed.downcase == "y"
             puts "Updating gemserver..."
             deploy
           end

--- a/lib/google/cloud/gemserver/configuration.rb
+++ b/lib/google/cloud/gemserver/configuration.rb
@@ -214,11 +214,16 @@ module Google
         end
 
         ##
-        # Saves the configuration file used for a deployment to Google Cloud
-        # Storage.
+        # Saves the configuration file used for a deployment.
         def save_to_cloud
           puts "Saving configuration"
           GCS.upload config_path, GCS_PATH
+        end
+
+        ##
+        # Deletes the configuration file used for a deployment
+        def delete_from_cloud
+          GCS.delete_file GCS_PATH
         end
 
         ##
@@ -292,8 +297,7 @@ module Google
         ##
         # Displays the configuration used by the current gemserver
         def self.display_config
-          config = GCS.get_file GCS_PATH
-          unless config
+          unless deployed?
             puts "No configuration found. Was the gemserver deployed?"
             return
           end
@@ -301,6 +305,15 @@ module Google
           puts "Gemserver is running with this configuration:"
           puts YAML.load_file(GCS_PATH).to_yaml
           cleanup
+        end
+
+        ##
+        # Checks if the gemserver was deployed by the existence of the config
+        # file used to deploy it on a specific path on Google Cloud Storage.
+        #
+        # @return [Boolean]
+        def self.deployed?
+          !GCS.get_file(GCS_PATH).nil?
         end
 
         private

--- a/test/google/cloud/gemserver/cli/server_test.rb
+++ b/test/google/cloud/gemserver/cli/server_test.rb
@@ -88,9 +88,11 @@ describe Google::Cloud::Gemserver::CLI::Server do
       mock_server.expect :call, nil, ["gcloud projects delete bob"]
 
       GCG::Configuration.stub :new, config_mock do
-        server.stub :run_cmd, mock_server do
-          server.delete "bob"
-          mock_server.verify
+        server.config.stub :delete_from_cloud, nil do
+          server.stub :run_cmd, mock_server do
+            server.delete "bob"
+            mock_server.verify
+          end
         end
       end
     end

--- a/test/google/cloud/gemserver/cli/server_test.rb
+++ b/test/google/cloud/gemserver/cli/server_test.rb
@@ -45,14 +45,16 @@ describe Google::Cloud::Gemserver::CLI::Server do
       app_path = "#{GCG::Configuration::SERVER_PATH}/app.yaml"
       ENV["APP_ENV"] = "production"
       mock_server = Minitest::Mock.new
-      mock_server.expect :call, nil, ["gcloud app deploy #{app_path} -q"]
+      mock_server.expect :call, true, ["gcloud app deploy #{app_path} -q"]
 
-      server.stub :run_cmd, mock_server do
+      server.stub :system, mock_server do
         server.stub :prepare_dir, nil do
           server.config.stub :save_to_cloud, nil do
             server.stub :setup_default_keys, nil do
-              server.deploy
-              mock_server.verify
+              server.stub :display_next_steps, nil do
+                server.deploy
+                mock_server.verify
+              end
             end
           end
         end
@@ -67,9 +69,11 @@ describe Google::Cloud::Gemserver::CLI::Server do
       mock_server = Minitest::Mock.new
       mock_server.expect :call, nil
 
-      server.stub :deploy, mock_server do
-        server.update
-        mock_server.verify
+      GCG::Configuration.stub :deployed?, true do
+        server.stub :deploy, mock_server do
+          server.update
+          mock_server.verify
+        end
       end
     end
   end
@@ -77,12 +81,17 @@ describe Google::Cloud::Gemserver::CLI::Server do
   describe ".delete" do
     it "calls gcloud projects delete" do
       server = GCG::CLI::Server.new
+
+      config_mock = Minitest::Mock.new
+      config_mock.expect :delete_from_cloud, nil
       mock_server = Minitest::Mock.new
       mock_server.expect :call, nil, ["gcloud projects delete bob"]
 
-      server.stub :run_cmd, mock_server do
-        server.delete "bob"
-        mock_server.verify
+      GCG::Configuration.stub :new, config_mock do
+        server.stub :run_cmd, mock_server do
+          server.delete "bob"
+          mock_server.verify
+        end
       end
     end
   end

--- a/test/google/cloud/gemserver/cli/server_test.rb
+++ b/test/google/cloud/gemserver/cli/server_test.rb
@@ -45,7 +45,7 @@ describe Google::Cloud::Gemserver::CLI::Server do
       app_path = "#{GCG::Configuration::SERVER_PATH}/app.yaml"
       ENV["APP_ENV"] = "production"
       mock_server = Minitest::Mock.new
-      mock_server.expect :call, nil, ["gcloud app deploy #{app_path} -q --project #{server.config[:proj_id]}"]
+      mock_server.expect :call, true, ["gcloud app deploy #{app_path} -q --project #{server.config[:proj_id]}"]
 
       server.stub :system, mock_server do
         server.stub :prepare_dir, nil do


### PR DESCRIPTION
Fixes #10 

Also updated `Google::Cloud::Gemserver::Authentication` such that it doesn't output tips to change authenticated accounts (from the `gcloud auth list` command).