### PR TITLE
Use googleauth tokens and App Engine API to implicitly validate requests

### DIFF
--- a/acceptance/perf/perf_test.rb
+++ b/acceptance/perf/perf_test.rb
@@ -58,7 +58,7 @@ describe Google::Cloud::Gemserver do
     `RUBYGEMS_HOST=#{url} gem yank --key #{KEY} #{GEM} --version #{VER}`
   }
 
-  let(:range) { 15..GCG::Backend::Key::KEY_LENGTH }
+  let(:range) { 15..15+GCG::Backend::Key::KEY_LENGTH }
 
   after(:all) do
     reset
@@ -94,7 +94,7 @@ describe Google::Cloud::Gemserver do
 
   it "can delete a gemserver key" do
     raw = `google-cloud-gemserver create-key -r #{HOST}`
-    key = raw[range]
+    key = raw[range].chomp
     Benchmark.bm(7) do |x|
       x.report("delete-key: "){ `google-cloud-gemserver delete-key -k #{key} -r #{HOST}` }
     end

--- a/google-cloud-gemserver.gemspec
+++ b/google-cloud-gemserver.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "google-cloud-resource_manager", "~> 0.24"
   spec.add_runtime_dependency "google-cloud-storage", "~> 1.1.0"
   spec.add_runtime_dependency "activesupport", "~> 4.2"
+  spec.add_runtime_dependency "googleauth", "~> 0.5.3"
 
   spec.add_development_dependency "mysql2", "~> 0.4"
   spec.add_development_dependency "filelock", "~> 1.1.1"

--- a/integration/integration_test.rb
+++ b/integration/integration_test.rb
@@ -15,6 +15,7 @@
 gem "minitest"
 require "minitest/autorun"
 require "minitest/rg"
+require "minitest/focus"
 require "google/cloud/gemserver"
 require "fileutils"
 
@@ -49,7 +50,7 @@ describe Google::Cloud::Gemserver do
     url = "http://#{HOST}/private"
     `RUBYGEMS_HOST=#{url} gem yank --key #{KEY} #{GEM} --version #{VER}`
   }
-  let(:range) { 15..GCG::Backend::Key::KEY_LENGTH }
+  let(:range) { 15..15+GCG::Backend::Key::KEY_LENGTH }
 
   after(:all) do
     reset
@@ -85,22 +86,22 @@ describe Google::Cloud::Gemserver do
     # response format => Generated key: KEY
     out = `google-cloud-gemserver create-key -r #{HOST}`
     assert out.size > 16
-    `google-cloud-gemserver delete-key -k #{out[range]} -r #{HOST}`
+    `google-cloud-gemserver delete-key -k #{out[range].chomp} -r #{HOST}`
     out = `google-cloud-gemserver create-key -p both -r #{HOST}`
     assert out.size > 16
-    `google-cloud-gemserver delete-key -k #{out[range]} -r #{HOST}`
+    `google-cloud-gemserver delete-key -k #{out[range].chomp} -r #{HOST}`
     out = `google-cloud-gemserver create-key -p write -r #{HOST}`
     assert out.size > 16
-    `google-cloud-gemserver delete-key -k #{out[range]} -r #{HOST}`
+    `google-cloud-gemserver delete-key -k #{out[range].chomp} -r #{HOST}`
     out = `google-cloud-gemserver create-key -p read -r #{HOST}`
     assert out.size > 16
-    `google-cloud-gemserver delete-key -k #{out[range]} -r #{HOST}`
+    `google-cloud-gemserver delete-key -k #{out[range].chomp} -r #{HOST}`
   end
 
   it "can delete a gemserver key" do
     raw = `google-cloud-gemserver create-key -r #{HOST}`
     refute raw.include? "Internal server error"
-    out = `google-cloud-gemserver delete-key -k #{raw[range]} -r #{HOST}`
+    out = `google-cloud-gemserver delete-key -k #{raw[range].chomp} -r #{HOST}`
     assert out.include?("success")
   end
 end

--- a/lib/google/cloud/gemserver/cli.rb
+++ b/lib/google/cloud/gemserver/cli.rb
@@ -120,13 +120,8 @@ module Google
           if ENV["APP_ENV"] == "test"
             return Backend::Key.create_key(options[:permissions])
           end
-          if Authentication.new.can_modify?
-            puts Request.new(options[:remote], options[:use_proj]).create_key(options[:permissions]).body
-            Backend::Key.output_key_info
-          else
-            puts "You are either not authenticated with gcloud or lack" \
-              " access to the gemserver and cannot create a key."
-          end
+          puts Request.new(options[:remote], options[:use_proj]).create_key(options[:permissions]).body
+          Backend::Key.output_key_info
         end
 
         ##
@@ -143,12 +138,7 @@ module Google
           if ENV["APP_ENV"] == "test"
             return Backend::Key.delete_key(options[:key])
           end
-          if Authentication.new.can_modify?
-            puts Request.new(options[:remote], options[:use_proj]).delete_key(options[:key]).body
-          else
-            puts "You are either not authenticated with gcloud or lack" \
-              " access to the gemserver and cannot delete a key."
-          end
+          puts Request.new(options[:remote], options[:use_proj]).delete_key(options[:key]).body
         end
 
         ##

--- a/lib/google/cloud/gemserver/cli/request.rb
+++ b/lib/google/cloud/gemserver/cli/request.rb
@@ -117,7 +117,7 @@ module Google
             auth = Google::Cloud::Gemserver::Authentication.new
             t = auth.access_token["access_token"]
             req = type.new endpoint
-            req["Authorization"] = Signet::OAuth2.generate_bearer_authorization_header(t)
+            req["Authorization"] = Signet::OAuth2.generate_bearer_authorization_header t
             if type != Net::HTTP::Get
               req.set_form_data(params) if params
             end

--- a/lib/google/cloud/gemserver/cli/request.rb
+++ b/lib/google/cloud/gemserver/cli/request.rb
@@ -117,7 +117,7 @@ module Google
             auth = Google::Cloud::Gemserver::Authentication.new
             t = auth.access_token["access_token"]
             req = type.new endpoint
-            req.initialize_http_header({"GEMSERVER-CREDENTIALS": t})
+            req["Authorization"] = Signet::OAuth2.generate_bearer_authorization_header(t)
             if type != Net::HTTP::Get
               req.set_form_data(params) if params
             end

--- a/lib/google/cloud/gemserver/cli/request.rb
+++ b/lib/google/cloud/gemserver/cli/request.rb
@@ -57,9 +57,7 @@ module Google
           #
           # @return [Net::HTTPResponse]
           def create_key permissions = nil
-            token = Google::Cloud::Gemserver::Authentication.new.gen_token
-            send_req Net::HTTP::Post, "/api/v1/key", {permissions: permissions,
-                                                      token: token}
+            send_req Net::HTTP::Post, "/api/v1/key", {permissions: permissions}
           end
 
           ##
@@ -69,8 +67,7 @@ module Google
           #
           # @return [Net::HTTPResponse]
           def delete_key key
-            token = Google::Cloud::Gemserver::Authentication.new.gen_token
-            send_req Net::HTTP::Put, "/api/v1/key", {key: key, token: token}
+            send_req Net::HTTP::Put, "/api/v1/key", {key: key}
           end
 
           ##
@@ -79,8 +76,7 @@ module Google
           #
           # @return [Net::HTTPResponse]
           def stats
-            token = Google::Cloud::Gemserver::Authentication.new.gen_token
-            send_req Net::HTTP::Post, "/api/v1/stats", {token: token}
+            send_req Net::HTTP::Post, "/api/v1/stats"
           end
 
           ##
@@ -118,7 +114,10 @@ module Google
           #
           # @return [String]
           def send_req type, endpoint, params = nil
+            auth = Google::Cloud::Gemserver::Authentication.new
+            t = auth.access_token["access_token"]
             req = type.new endpoint
+            req.initialize_http_header({"GEMSERVER-CREDENTIALS": t})
             if type != Net::HTTP::Get
               req.set_form_data(params) if params
             end

--- a/lib/google/cloud/gemserver/cli/request.rb
+++ b/lib/google/cloud/gemserver/cli/request.rb
@@ -57,7 +57,9 @@ module Google
           #
           # @return [Net::HTTPResponse]
           def create_key permissions = nil
-            send_req Net::HTTP::Post, "/api/v1/key", {permissions: permissions}
+            token = Google::Cloud::Gemserver::Authentication.new.gen_token
+            send_req Net::HTTP::Post, "/api/v1/key", {permissions: permissions,
+                                                      token: token}
           end
 
           ##
@@ -67,7 +69,8 @@ module Google
           #
           # @return [Net::HTTPResponse]
           def delete_key key
-            send_req Net::HTTP::Put, "/api/v1/key", {key: key}
+            token = Google::Cloud::Gemserver::Authentication.new.gen_token
+            send_req Net::HTTP::Put, "/api/v1/key", {key: key, token: token}
           end
 
           ##
@@ -76,7 +79,8 @@ module Google
           #
           # @return [Net::HTTPResponse]
           def stats
-            send_req Net::HTTP::Get, "/api/v1/stats"
+            token = Google::Cloud::Gemserver::Authentication.new.gen_token
+            send_req Net::HTTP::Post, "/api/v1/stats", {token: token}
           end
 
           ##

--- a/lib/google/cloud/gemserver/configuration.rb
+++ b/lib/google/cloud/gemserver/configuration.rb
@@ -196,10 +196,6 @@ module Google
         DEFAULT_KEY_NAME = "master-gemserver-key".freeze
 
         ##
-        # File path of the token on Google Cloud Storage.
-        TOKEN_PATH = "/tmp/tokens/auth_token".freeze
-
-        ##
         # The configuration used by the gemserver.
         # @return [Hash]
         attr_accessor :config

--- a/lib/google/cloud/gemserver/configuration.rb
+++ b/lib/google/cloud/gemserver/configuration.rb
@@ -196,6 +196,10 @@ module Google
         DEFAULT_KEY_NAME = "master-gemserver-key".freeze
 
         ##
+        # File path of the token on Google Cloud Storage.
+        TOKEN_PATH = "/tmp/tokens/auth_token".freeze
+
+        ##
         # The configuration used by the gemserver.
         # @return [Hash]
         attr_accessor :config

--- a/lib/patched/web.rb
+++ b/lib/patched/web.rb
@@ -21,29 +21,56 @@ Gemstash::Web.class_eval do
   ##
   # Displays statistics on the currently deployed gemserver such as private
   # gems, cached gems, gemserver creation time, etc.
-  get "/api/v1/stats" do
-    content_type "application/json;charset=UTF-8"
-    Google::Cloud::Gemserver::Backend::Stats.new.run
+  post "/api/v1/stats" do
+    auth = Google::Cloud::Gemserver::Authentication.new
+    begin
+      if auth.check params["token"]
+        content_type "application/json;charset=UTF-8"
+        Google::Cloud::Gemserver::Backend::Stats.new.run
+      else
+        halt 401, "Unauthorized operation."
+      end
+    ensure
+      auth.delete_token params["token"]
+    end
   end
 
   ##
   # Creates a key used for installing or pushing gems to the gemserver
   # with given permissions. By default, a key with all permissions is created.
   post "/api/v1/key" do
-    key = Google::Cloud::Gemserver::Backend::Key.create_key params["permissions"]
-    content_type "application/json;charset=UTF-8"
-    "Generated key: #{key}"
+    auth = Google::Cloud::Gemserver::Authentication.new
+    begin
+      if auth.check params["token"]
+        key = Google::Cloud::Gemserver::Backend::Key.create_key params["permissions"]
+        content_type "application/json;charset=UTF-8"
+        "Generated key: #{key}"
+      else
+        halt 401, "Unauthorized operation."
+      end
+    ensure
+      auth.delete_token params["token"]
+    end
   end
 
   ##
   # Deletes a key.
   put "/api/v1/key" do
-    res = Google::Cloud::Gemserver::Backend::Key.delete_key params["key"]
-    content_type "application/json;charset=UTF-8"
-    if res
-      "Deleted key #{params["key"]} successfully."
-    else
-      "Deleting key #{params["key"]} failed."
+    auth = Google::Cloud::Gemserver::Authentication.new
+    begin
+      if auth.check params["token"]
+        res = Google::Cloud::Gemserver::Backend::Key.delete_key params["key"]
+        content_type "application/json;charset=UTF-8"
+        if res
+          "Deleted key #{params["key"]} successfully."
+        else
+          "Deleting key #{params["key"]} failed."
+        end
+      else
+        halt 401, "Unauthorized operation."
+      end
+    ensure
+      auth.delete_token params["token"]
     end
   end
 end

--- a/lib/patched/web.rb
+++ b/lib/patched/web.rb
@@ -23,7 +23,7 @@ Gemstash::Web.class_eval do
   # gems, cached gems, gemserver creation time, etc.
   post "/api/v1/stats" do
     auth = Google::Cloud::Gemserver::Authentication.new
-    if auth.validate_token request.env["HTTP_GEMSERVER_CREDENTIALS"]
+    if auth.validate_token request.env["HTTP_AUTHORIZATION"]
       content_type "application/json;charset=UTF-8"
       Google::Cloud::Gemserver::Backend::Stats.new.run
     else
@@ -36,7 +36,7 @@ Gemstash::Web.class_eval do
   # with given permissions. By default, a key with all permissions is created.
   post "/api/v1/key" do
     auth = Google::Cloud::Gemserver::Authentication.new
-    if auth.validate_token request.env["HTTP_GEMSERVER_CREDENTIALS"]
+    if auth.validate_token request.env["HTTP_AUTHORIZATION"]
       key = Google::Cloud::Gemserver::Backend::Key.create_key params["permissions"]
       content_type "application/json;charset=UTF-8"
       "Generated key: #{key}"
@@ -49,7 +49,7 @@ Gemstash::Web.class_eval do
   # Deletes a key.
   put "/api/v1/key" do
     auth = Google::Cloud::Gemserver::Authentication.new
-    if auth.validate_token request.env["HTTP_GEMSERVER_CREDENTIALS"]
+    if auth.validate_token request.env["HTTP_AUTHORIZATION"]
       res = Google::Cloud::Gemserver::Backend::Key.delete_key params["key"]
       content_type "application/json;charset=UTF-8"
       if res

--- a/test/google/cloud/gemserver/authentication_test.rb
+++ b/test/google/cloud/gemserver/authentication_test.rb
@@ -14,6 +14,7 @@
 
 require "helper"
 require "yaml"
+require "tempfile"
 
 describe Google::Cloud::Gemserver::Authentication do
   describe ".new" do
@@ -24,6 +25,8 @@ describe Google::Cloud::Gemserver::Authentication do
 
   let(:owners) { ["serviceaccount:owner_a", "user:owner_b"] }
   let(:editors) { ["serviceaccount:editor_a", "user:editor_b"] }
+  let(:token) { "test-token" }
+  let(:invalid_token) { "wrong-token" }
 
   describe ".can_modify?" do
     it "returns true iff the logged in user is the project owner" do
@@ -59,6 +62,100 @@ describe Google::Cloud::Gemserver::Authentication do
             refute auth.can_modify?
           end
         end
+      end
+    end
+  end
+
+  describe ".gen_token" do
+    it "creates and uploads a token if the user is authenticated" do
+      auth = GCG::Authentication.new
+
+      gen_mock = Minitest::Mock.new
+      gen_mock.expect :call, token
+
+      upload_mock = Minitest::Mock.new
+      upload_mock.expect :call, nil, [Tempfile, "#{GCG::Configuration::TOKEN_PATH}-#{token}"]
+
+      auth.stub :can_modify?, true do
+        GCG::GCS.stub :upload, upload_mock do
+          SecureRandom.stub :uuid, gen_mock do
+            auth.gen_token
+            gen_mock.verify
+            upload_mock.verify
+          end
+        end
+      end
+    end
+
+    it "does nothing if user is not authenticated" do
+      auth = GCG::Authentication.new
+
+      auth.stub :can_modify?, false do
+        assert_nil auth.gen_token
+      end
+    end
+  end
+
+  describe ".delete_token" do
+    it "deletes the token" do
+      auth = GCG::Authentication.new
+
+      gcs_mock = Minitest::Mock.new
+      gcs_mock.expect :call, nil, ["#{GCG::Configuration::TOKEN_PATH}-#{token}"]
+
+      auth.stub :can_modify?, true do
+        GCG::GCS.stub :delete_file, gcs_mock do
+          auth.delete_token token
+          gcs_mock.verify
+        end
+      end
+    end
+  end
+
+  describe ".check" do
+    it "returns true if token exists and value matches" do
+      auth = GCG::Authentication.new
+
+      string_mock = Minitest::Mock.new
+      string_mock.expect :string, token
+
+      dl_mock = Minitest::Mock.new
+      dl_mock.expect :download, string_mock
+
+      file_mock = Minitest::Mock.new
+      file_mock.expect :call, dl_mock, ["#{GCG::Configuration::TOKEN_PATH}-#{token}"]
+
+      GCG::GCS.stub :on_gcs?, true do
+        GCG::GCS.stub :get_file, file_mock do
+          assert auth.check(token)
+        end
+      end
+    end
+
+    it "returns false if the token has the wrong value" do
+      auth = GCG::Authentication.new
+
+      string_mock = Minitest::Mock.new
+      string_mock.expect :string, token
+
+      dl_mock = Minitest::Mock.new
+      dl_mock.expect :download, string_mock
+
+      file_mock = Minitest::Mock.new
+      file_mock.expect :call, dl_mock, ["#{GCG::Configuration::TOKEN_PATH}-#{invalid_token}"]
+
+      GCG::GCS.stub :on_gcs?, true do
+        GCG::GCS.stub :get_file, file_mock do
+          refute auth.check(invalid_token)
+        end
+      end
+    end
+
+    it "returns false if the token does not exist" do
+      auth = GCG::Authentication.new
+
+      GCG::GCS.stub :on_gcs?, false do
+        refute auth.check(token)
       end
     end
   end

--- a/test/google/cloud/gemserver/cli/request_test.rb
+++ b/test/google/cloud/gemserver/cli/request_test.rb
@@ -74,7 +74,7 @@ describe Google::Cloud::Gemserver::CLI::Request do
       mock.expect :access_token, token
 
       http_mock = Minitest::Mock.new
-      http_mock.expect :initialize_http_header, nil, [Hash]
+      http_mock.expect :[]=, nil, [String, String]
 
       GCG::Authentication.stub :new, mock do
         req.http.stub :request, nil do

--- a/test/google/cloud/gemserver/cli/request_test.rb
+++ b/test/google/cloud/gemserver/cli/request_test.rb
@@ -16,6 +16,11 @@ require "helper"
 require "net/http"
 
 describe Google::Cloud::Gemserver::CLI::Request do
+
+  let(:token) {
+    "test-token"
+  }
+
   describe "Request.new" do
     it "creates an HTTP object for the gemserver" do
       bkd = GCG::CLI::Request.new "google.com"
@@ -27,10 +32,16 @@ describe Google::Cloud::Gemserver::CLI::Request do
     it "calls send_req with the correct arguments" do
       bkd = GCG::CLI::Request.new "google.com"
       mock = Minitest::Mock.new
-      mock.expect :call, nil, [Net::HTTP::Post, "/api/v1/key", {permissions: nil}]
-      bkd.stub :send_req, mock do
-        bkd.create_key
-        mock.verify
+      mock.expect :call, nil, [Net::HTTP::Post, "/api/v1/key", {permissions: nil, token: token}]
+
+      auth_mock = Minitest::Mock.new
+      auth_mock.expect :gen_token, token
+
+      GCG::Authentication.stub :new, auth_mock do
+        bkd.stub :send_req, mock do
+          bkd.create_key
+          mock.verify
+        end
       end
     end
   end
@@ -39,10 +50,16 @@ describe Google::Cloud::Gemserver::CLI::Request do
     it "calls send_req with the correct arguments" do
       bkd = GCG::CLI::Request.new "google.com"
       mock = Minitest::Mock.new
-      mock.expect :call, nil, [Net::HTTP::Put, "/api/v1/key", {key: "key"}]
-      bkd.stub :send_req, mock do
-        bkd.delete_key "key"
-        mock.verify
+      mock.expect :call, nil, [Net::HTTP::Put, "/api/v1/key", {key: "key", token: token}]
+
+      auth_mock = Minitest::Mock.new
+      auth_mock.expect :gen_token, token
+
+      GCG::Authentication.stub :new, auth_mock do
+        bkd.stub :send_req, mock do
+          bkd.delete_key "key"
+          mock.verify
+        end
       end
     end
   end
@@ -51,10 +68,17 @@ describe Google::Cloud::Gemserver::CLI::Request do
     it "calls send_req with the correct arguments" do
       bkd = GCG::CLI::Request.new "google.com"
       mock = Minitest::Mock.new
-      mock.expect :call, nil, [Net::HTTP::Get, "/api/v1/stats"]
-      bkd.stub :send_req, mock do
-        bkd.stats
-        mock.verify
+      mock.expect :call, nil, [Net::HTTP::Post, "/api/v1/stats", {token: token}]
+
+      auth_mock = Minitest::Mock.new
+      auth_mock.expect :gen_token, token
+
+      GCG::Authentication.stub :new, auth_mock do
+        bkd.stub :send_req, mock do
+          bkd.stats
+          mock.verify
+          auth_mock.verify
+        end
       end
     end
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -15,6 +15,7 @@
 gem "minitest"
 
 require "minitest/autorun"
+require "minitest/focus"
 require "minitest/rg"
 require "google/cloud/gemserver"
 


### PR DESCRIPTION
Fixes #27.

~~The new authorization flow is to create a token that gets uploaded to GCS and appended to every request. The token is only generated if the user is authenticated with gcloud and has access to the project the gemserver is in. The server checks if the token file exists and its value matches the token in the request for the request to succeed. Upon request completion, the token file is deleted. The token files are unique so concurrent requests are not an issue.~~

If the user is authenticated with gcloud, a token is generated by the `googleauth` gem and set as a header on every request. ~~The server checks the header and validates it with the tokeninfo API for requests.~~
The server issues a redundant request to update the parent project of the gemserver with its current settings; this implicitly checks that the token has edit access and privileged operations that require edit access should succeed. Only `create_key`, `delete_key`, and `stats` are privileged operations and make this extra request.