### PR TITLE
Update update and delete commands

### DIFF
--- a/lib/google/cloud/gemserver/backend/storage_sync.rb
+++ b/lib/google/cloud/gemserver/backend/storage_sync.rb
@@ -89,7 +89,7 @@ module Google
           # @return [String]
           def gemstash_dir
             if ENV["APP_ENV"] == "production"
-              "/root/.gemstash"
+              Configuration::GEMSTASH_DIR
             else
               File.expand_path("~/.gemstash")
             end

--- a/lib/google/cloud/gemserver/configuration.rb
+++ b/lib/google/cloud/gemserver/configuration.rb
@@ -196,6 +196,10 @@ module Google
         DEFAULT_KEY_NAME = "master-gemserver-key".freeze
 
         ##
+        # @private The path gem data is stored
+        GEMSTASH_DIR = "/root/.gemstash".freeze
+
+        ##
         # The configuration used by the gemserver.
         # @return [Hash]
         attr_accessor :config


### PR DESCRIPTION
Update no longer prompts to create default keys again or displays next steps (user assumed to have seen it during their initial deploy).

Delete warns user for a full GCP project deletion or asks them to disable it manually.